### PR TITLE
Add manage_json_packages flag to bitbucket::facts

### DIFF
--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -15,11 +15,12 @@
 # class { 'bitbucket::facts': }
 #
 class bitbucket::facts(
-  $ensure        = 'present',
-  $port          = '7990',
-  $uri           = '127.0.0.1',
-  $context_path  = $bitbucket::context_path,
-  $json_packages = $bitbucket::params::json_packages,
+  $ensure               = 'present',
+  $port                 = '7990',
+  $uri                  = '127.0.0.1',
+  $context_path         = $bitbucket::context_path,
+  $json_packages        = $bitbucket::params::json_packages,
+  $manage_json_packages = $bitbucket::params::manage_json_packages,
 ) inherits bitbucket {
 
   # Puppet Enterprise supplies its own ruby version if your using it.
@@ -43,9 +44,11 @@ class bitbucket::facts(
     }
   }
 
-  if $::osfamily == 'RedHat' and $::puppetversion !~ /Puppet Enterprise/ {
-    package { $json_packages:
-      ensure => present,
+  if $manage_json_packages {
+    if $::osfamily == 'RedHat' and $::puppetversion !~ /Puppet Enterprise/ {
+      package { $json_packages:
+        ensure => present,
+      }
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,6 +3,8 @@
 # Defines default values for bitbucket module
 #
 class bitbucket::params {
+  $manage_json_packages = true
+
   case $::osfamily {
     /RedHat/: {
       if $::operatingsystemmajrelease == '7' {


### PR DESCRIPTION
bitbucket::facts makes assumptions that the json rubygem package is not
being installed elsewhere in the catalog. Add a manage_json_packages flag
to disable installing the packages if required by the end user to avoid
a conflict.

unit tests pass OK. I haven't run the integration tests, I don't have beaker setup.
Doesn't seem to be any existing documentation for the bitbucket::facts class to update.
