### PR TITLE
Add umask parameter to override the bitbucket user's umask

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ If the bitbucket service is managed outside of puppet the stop_bitbucket paramat
 Module to use for installed bitbucket archive fille. Supports puppet-archive and nanliu-staging. Defaults to 'archive'. Archive supports md5 hash checking, Staging supports s3 buckets. 
 #####`config_properties`
 Extra configuration options for bitbucket (bitbucket-config.properties). See https://confluence.atlassian.com/display/STASH/Bitbucket+config+properties for available options. Must be a hash, Default: {}
+#####`umask`
+Specify the umask bitbucket should run with. Defaults to undef, in which case the user account's default umask is left untouched.
 
 ####Backup parameters####
 #####`backup_ensure`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,7 @@ class bitbucket(
   $jvm_optional = '-XX:-HeapDumpOnOutOfMemoryError',
   $jvm_support_recommended_args = '',
   $java_opts    = '',
+  $umask        = undef,
 
   # Bitbucket Settings
   $version      = '4.2.0',

--- a/templates/setenv.sh.erb
+++ b/templates/setenv.sh.erb
@@ -48,6 +48,9 @@ JVM_REQUIRED_ARGS="-Djava.awt.headless=true -Dfile.encoding=${JVM_FILE_ENCODING}
 # the default settings of the Bitbucket user is they are not sufficiently secure.
 #
 # umask 0027
+<% if scope.lookupvar('bitbucket::umask') -%>
+umask <%= scope.lookupvar('bitbucket::umask') %>
+<% end -%>
 
 #-----------------------------------------------------------------------------------
 # JMX


### PR DESCRIPTION
By default, bitbucket uses the user account's current umask, which
warns during startup may not be secure, and recommends '0027'. This change
adds a umask parameter to init.pp and if specified adds it to setenv.sh.
It defaults to undef to preserve existing behaviour with previous versions of the module.
README documentation updated. 