### PR TITLE
Allow disabling of backup client installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,8 @@ Extra configuration options for bitbucket (bitbucket-config.properties). See htt
 Specify the umask bitbucket should run with. Defaults to undef, in which case the user account's default umask is left untouched.
 
 ####Backup parameters####
+#####`manage_backup`
+Whether to manage installation of backup client or not. Defaults to true.
 #####`backup_ensure`
 Enable or disable the backup cron job. Defaults to present.
 #####`backupclient_version`

--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -4,6 +4,7 @@
 # This installs the bitbucket backup client
 #
 class bitbucket::backup(
+  $manage_backup        = $bitbucket::manage_backup,
   $ensure               = $bitbucket::backup_ensure,
   $schedule_hour        = $bitbucket::backup_schedule_hour,
   $schedule_minute      = $bitbucket::backup_schedule_minute,
@@ -22,88 +23,90 @@ class bitbucket::backup(
   $keep_age             = $bitbucket::backup_keep_age,
   ) {
 
-  $appdir = "${backup_home}/${product}-backup-client-${version}"
+  if $manage_backup {
+    $appdir = "${backup_home}/${product}-backup-client-${version}"
 
-  file { $backup_home:
-    ensure => 'directory',
-    owner  => $user,
-    group  => $group,
-  }
-  file { "${backup_home}/archives":
-    ensure => 'directory',
-    owner  => $user,
-    group  => $group,
-  }
+    file { $backup_home:
+      ensure => 'directory',
+      owner  => $user,
+      group  => $group,
+    }
+    file { "${backup_home}/archives":
+      ensure => 'directory',
+      owner  => $user,
+      group  => $group,
+    }
 
-  $file = "${product}-backup-distribution-${version}.${backup_format}"
+    $file = "${product}-backup-distribution-${version}.${backup_format}"
 
-  file { $appdir:
-    ensure => 'directory',
-    owner  => $user,
-    group  => $group,
-  }
-  
-  file { '/var/tmp/downloadurl':
-    content => "${download_url}/${version}/${file}",
-  }
+    file { $appdir:
+      ensure => 'directory',
+      owner  => $user,
+      group  => $group,
+    }
 
-  case $deploy_module {
-    'staging': {
-      require staging
-      staging::file { $file:
-        source  => "${download_url}/${version}/${file}",
-        timeout => 1800,
-      } ->
-      staging::extract { $file:
-        target  => $appdir,
-        creates => "${appdir}/lib",
-        strip   => 1,
-        user    => $user,
-        group   => $group,
-        require => [ User[$user], File[$appdir] ],
+    file { '/var/tmp/downloadurl':
+      content => "${download_url}/${version}/${file}",
+    }
+
+    case $deploy_module {
+      'staging': {
+        require staging
+        staging::file { $file:
+          source  => "${download_url}/${version}/${file}",
+          timeout => 1800,
+        } ->
+        staging::extract { $file:
+          target  => $appdir,
+          creates => "${appdir}/lib",
+          strip   => 1,
+          user    => $user,
+          group   => $group,
+          require => [ User[$user], File[$appdir] ],
+        }
+      }
+      'archive': {
+        archive { "/tmp/${file}":
+          ensure       => present,
+          extract      => true,
+          extract_path => $backup_home,
+          source       => "${download_url}/${version}/${file}",
+          user         => $user,
+          group        => $group,
+          creates      => "${appdir}/lib",
+          cleanup      => true,
+          before       => File[$appdir],
+        }
+      }
+      default: {
+        fail('deploy_module parameter must equal "archive" or staging""')
       }
     }
-    'archive': {
-      archive { "/tmp/${file}":
-        ensure       => present,
-        extract      => true,
-        extract_path => $backup_home,
-        source       => "${download_url}/${version}/${file}",
-        user         => $user,
-        group        => $group,
-        creates      => "${appdir}/lib",
-        cleanup      => true,
-        before       => File[$appdir],
-      }
+
+    if $javahome {
+      $java_bin = "${javahome}/bin/java"
+    } else {
+      $java_bin = '/usr/bin/java'
     }
-    default: {
-      fail('deploy_module parameter must equal "archive" or staging""')
+
+    # Enable Cronjob
+    $backup_cmd = "${java_bin} -Dbitbucket.password=\"${backuppass}\" -Dbitbucket.user=\"${backupuser}\" -Dbitbucket.baseUrl=\"http://localhost:7990\" -Dbitbucket.home=${homedir} -Dbackup.home=${backup_home}/archives -jar ${appdir}/bitbucket-backup-client.jar"
+
+    cron { 'Backup Bitbucket':
+      ensure  => $ensure,
+      command => $backup_cmd,
+      user    => $user,
+      hour    => $schedule_hour,
+      minute  => $schedule_minute,
     }
-  }
 
-  if $javahome {
-    $java_bin = "${javahome}/bin/java"
-  } else {
-    $java_bin = '/usr/bin/java'
-  }
-
-  # Enable Cronjob
-  $backup_cmd = "${java_bin} -Dbitbucket.password=\"${backuppass}\" -Dbitbucket.user=\"${backupuser}\" -Dbitbucket.baseUrl=\"http://localhost:7990\" -Dbitbucket.home=${homedir} -Dbackup.home=${backup_home}/archives -jar ${appdir}/bitbucket-backup-client.jar"
-
-  cron { 'Backup Bitbucket':
-    ensure  => $ensure,
-    command => $backup_cmd,
-    user    => $user,
-    hour    => $schedule_hour,
-    minute  => $schedule_minute,
-  }
-
-  tidy { 'remove_old_archives':
-    path    => "${backup_home}/archives",
-    age     => $keep_age,
-    matches => '*.tar',
-    type    => 'mtime',
-    recurse => 2,
+    tidy { 'remove_old_archives':
+      path    => "${backup_home}/archives",
+      age     => $keep_age,
+      matches => '*.tar',
+      type    => 'mtime',
+      recurse => 2,
+    }
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,6 +51,7 @@ class bitbucket(
   $checksum     = undef,
 
   # Backup Settings
+  $manage_backup          = true,
   $backup_ensure          = 'present',
   $backupclient_url       = 'https://maven.atlassian.com/content/groups/public/com/atlassian/bitbucket/server/backup/bitbucket-backup-distribution',
   $backup_format          = 'zip',

--- a/spec/classes/bitbucket_backup_disabled_spec.rb
+++ b/spec/classes/bitbucket_backup_disabled_spec.rb
@@ -9,8 +9,8 @@ describe 'bitbucket' do
             facts
           end
           let(:params) do
-              { :manage_backup => false, }
-            end
+            { :manage_backup => false, }
+          end
 
           context 'no install of bitbucket backup client' do
             it 'should not deploy bitbucket backup client' do

--- a/spec/classes/bitbucket_backup_disabled_spec.rb
+++ b/spec/classes/bitbucket_backup_disabled_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper.rb'
+
+describe 'bitbucket' do
+  describe 'bitbucket::backup' do
+    context 'supported operating systems' do
+      on_supported_os.each do |os, facts|
+        context "on #{os} #{facts}" do
+          let(:facts) do
+            facts
+          end
+          let(:params) do
+              { :manage_backup => false, }
+            end
+
+          context 'no install of bitbucket backup client' do
+            it 'should not deploy bitbucket backup client' do
+              should_not contain_archive("/tmp/bitbucket-backup-distribution-#{BACKUP_VERSION}.zip")
+            end
+
+            it 'should not manage the bitbucket-backup directories' do
+              should_not contain_file('/opt/bitbucket-backup')
+                .with('ensure' => 'directory')
+            end
+            it 'should not manage the backup cron job' do
+              should_not contain_cron('Backup Bitbucket')
+                .with('ensure'  => 'present',
+                      'command' => "/usr/bin/java -Dbitbucket.password=\"password\" -Dbitbucket.user=\"admin\" -Dbitbucket.baseUrl=\"http://localhost:7990\" -Dbitbucket.home=/home/bitbucket -Dbackup.home=/opt/bitbucket-backup/archives -jar /opt/bitbucket-backup/bitbucket-backup-client-#{BACKUP_VERSION}/bitbucket-backup-client.jar",
+                      'user'    => 'atlbitbucket',
+                      'hour'    => '5',
+                      'minute'  => '0',)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR enables the possibility to disable the installation of the Bitbucket backup client completely. Sometimes the backup client is not required because backups are solved in other ways. One could simply disable the cron for the backup, but when the client is not needed at all it is better to be able to completely disable the installation.

For this I added a new `manage_backup` parameter in the main class. It is set to `true` by default to keep bc with current behavior, so that upgrades don't change how existing installations work.

I'm not particularly happy about the big diff for the backup class, but I didn't come up with a better way. If you have a better idea please advise.

Also, the acceptance tests fail, but they already fail without this change, so I'm not sure what to do about that.