### PR TITLE
Update redhat initscript to run as the target user

### DIFF
--- a/templates/bitbucket.initscript.redhat.erb
+++ b/templates/bitbucket.initscript.redhat.erb
@@ -32,6 +32,16 @@ lockfile=/var/lock/subsys/$SERVICE
 
 export JAVA_HOME=<%= scope.lookupvar('bitbucket::javahome') %>
 export CATALINA_HOME=<%= scope.lookupvar('bitbucket::webappdir') %>
+export BITBUCKET_HOME=<%= scope.lookupvar('bitbucket::homedir') %>
+export BITBUCKET_USER=<%= scope.lookupvar('bitbucket::user') %>
+
+if [ -z "$BITBUCKET_USER" ] || [ $(id -un) == "$BITBUCKET_USER" ]; then
+    sucmd=""
+elif [ -x "/sbin/runuser" ]; then
+    sucmd="/sbin/runuser ${BITBUCKET_USER}"
+else
+    sucmd="su -u ${BITBUCKET_USER}"
+fi
 
 
 function restart() {
@@ -41,7 +51,7 @@ function restart() {
 
 function stop() {
   echo -n $"Shutting down $SERVICE: "
-  <%= scope.lookupvar('bitbucket::webappdir') %>/bin/stop-bitbucket.sh
+  ${sucmd} <%= scope.lookupvar('bitbucket::webappdir') %>/bin/stop-bitbucket.sh
   RETVAL=$?
   echo
 
@@ -52,7 +62,7 @@ function stop() {
 
 function start() {
   echo -n $"Starting $SERVICE: "
-  <%= scope.lookupvar('bitbucket::webappdir') %>/bin/start-bitbucket.sh
+  ${sucmd} <%= scope.lookupvar('bitbucket::webappdir') %>/bin/start-bitbucket.sh
   RETVAL=$?
   echo
 


### PR DESCRIPTION
In at least BitBucket 4.6, maybe earlier, the distrubuted copy of
bin/set-bitbucket-user.sh sets BITBUCKET_USER="", nullifying the switch
user code in the startup scripts. This means bitbucket runs as root, and the
elasticsearch underpinning code search refuses to start.

This commit sets BITBUCKET_HOME and BITBUCKET_USER env vars in the redhat init
script required for startup, and adds user-switch logic into the init script,
bringing it a bit closer to the debian init script.

Tested on CentOS6.7 with BitBucket 4.6.1. Spec tests pass, but I haven't got a suitable environment for running the beaker acceptance tests in set up so not been able to run those.