### PR TITLE
Fix dependencies when $manage_usr_grp=false

### DIFF
--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -21,6 +21,7 @@ class bitbucket::backup(
   $backup_home          = $bitbucket::backup_home,
   $javahome             = $bitbucket::javahome,
   $keep_age             = $bitbucket::backup_keep_age,
+  $manage_usr_grp       = $bitbucket::manage_usr_grp,
   ) {
 
   if $manage_backup {
@@ -62,7 +63,11 @@ class bitbucket::backup(
           strip   => 1,
           user    => $user,
           group   => $group,
-          require => [ User[$user], File[$appdir] ],
+          require => File[$appdir],
+        }
+
+        if $manage_usr_grp {
+          User[$user] -> Staging::Extract[$file]
         }
       }
       'archive': {


### PR DESCRIPTION
In various places the dependencies are written making the assumption
$manage_usr_grp is always true. When set to false, the User[$user] resource
is not in the catalog and may not be referenced.

This commit separates out the dependencies on User[$user] using -> and ~>
operators, so that they're only included in the catalog if $manage_usr_grp
is enabled.

Tested on CentOS6.7 and bitbucket 4.6. Spec tests pass clean. Beaker acceptance tests not run as no suitable environment for doing so.