### PR TITLE
Uses tomcat_port instead of hard coded port.

### DIFF
--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -95,7 +95,11 @@ class bitbucket::backup(
     }
 
     # Enable Cronjob
-    $backup_cmd = "${java_bin} -Dbitbucket.password=\"${backuppass}\" -Dbitbucket.user=\"${backupuser}\" -Dbitbucket.baseUrl=\"http://localhost:7990\" -Dbitbucket.home=${homedir} -Dbackup.home=${backup_home}/archives -jar ${appdir}/bitbucket-backup-client.jar"
+    $backup_cmd = "${java_bin} -Dbitbucket.password=\"${backuppass}\"\
+ -Dbitbucket.user=\"${backupuser}\"\
+ -Dbitbucket.baseUrl=\"http://localhost:${bitbucket::tomcat_port}\"\
+ -Dbitbucket.home=${homedir} -Dbackup.home=${backup_home}/archives\
+ -jar ${appdir}/bitbucket-backup-client.jar"
 
     cron { 'Backup Bitbucket':
       ensure  => $ensure,


### PR DESCRIPTION
The bitbucket backup command should use the tomcat_port defined in the main bitbucket class.  This PR changes the port that is hardcoded from 7990 to bitbucket::tomcat_port.  I also ensured the $backup_cmd compiles with puppet lint 80 char line rules.
See [issue 26](https://github.com/danofthewired/puppet-bitbucket/issues/26).