### PR TITLE
Fixed puppet 4 open source incompatibility.

### DIFF
--- a/lib/facter/bitbucket_facts.rb
+++ b/lib/facter/bitbucket_facts.rb
@@ -1,0 +1,24 @@
+# Fact: bitbucket_builddate, bitbucket_buildnumber, bitbucket_displayname, bitbucket_version
+#
+# Purpose: Return facts for the running version of bitbucket.
+#
+require 'json'
+require 'open-uri'
+
+# get url of bitbucket
+file = File.open("/etc/bitbucket_url.txt", "rb")
+bitbucket_url = file.read
+begin
+  url = 'bitbucket_url'
+  info = open(url, &:read)
+rescue
+  exit 0
+end
+pinfo = JSON.load(info)
+pinfo.each do |key, value|
+  actual_value = value
+  if value.is_a? Array
+     actual_value = value.join(',')
+  end
+  puts "bitbucket_#{key.chomp()}=#{actual_value.chomp}"
+end

--- a/lib/facter/bitbucket_facts.rb
+++ b/lib/facter/bitbucket_facts.rb
@@ -6,8 +6,12 @@ require 'json'
 require 'open-uri'
 
 # get url of bitbucket
-file = File.open("/etc/bitbucket_url.txt", "rb")
-bitbucket_url = file.read
+begin
+  file = File.open("/etc/bitbucket_url.txt", "rb")
+  bitbucket_url = file.read
+rescue
+  exit 0
+end
 begin
   url = 'bitbucket_url'
   info = open(url, &:read)

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -22,37 +22,15 @@ class bitbucket::facts(
   $json_packages = $bitbucket::params::json_packages,
 ) inherits bitbucket {
 
-  # Puppet Enterprise supplies its own ruby version if your using it.
-  # A modern ruby version is required to run the executable fact
-  if $::puppetversion =~ /Puppet Enterprise/ {
-    $ruby_bin = '/opt/puppet/bin/ruby'
-    $dir      = 'puppetlabs/'
-  } else {
-    $ruby_bin = '/usr/bin/env ruby'
-    $dir      = ''
-  }
-
-  if ! defined(File["/etc/${dir}facter"]) {
-    file { "/etc/${dir}facter":
-      ensure  => directory,
-    }
-  }
-  if ! defined(File["/etc/${dir}facter/facts.d"]) {
-    file { "/etc/${dir}facter/facts.d":
-      ensure  => directory,
-    }
-  }
-
   if $::osfamily == 'RedHat' and $::puppetversion !~ /Puppet Enterprise/ {
     package { $json_packages:
       ensure => present,
     }
   }
 
-  file { "/etc/${dir}facter/facts.d/bitbucket_facts.rb":
+  file{'/etc/bitbucket_url.txt':
     ensure  => $ensure,
-    content => template('bitbucket/facts.rb.erb'),
-    mode    => '0500',
+    content => "http://${uri}:${port}${context_path}/rest/api/1.0/\
+application-properties",
   }
-
 }

--- a/manifests/gc.pp
+++ b/manifests/gc.pp
@@ -27,7 +27,7 @@ class bitbucket::gc(
 
   include ::bitbucket::params
 
-  if versioncmp($::bitbucket_version, '3.2') < 0 {
+  if $::bitbucket_version and versioncmp($::bitbucket_version, '3.2') < 0 {
     $shared = ''
   } else {
     $shared = '/shared'


### PR DESCRIPTION
The bitbucket module doesn't work when using the bitbucket::gc class in a Puppet 4 environment.  This is caused primarily by the the bitbucket_version variable not being set due to facter pathing.  This patch does the following to fix this problem:

-  Removed using the global fact directory.
- Moved facts to the module 'lib' directory.
- Added a configuration file in /etc.
- Fails gracefully if fact is unavailable.