### PR TITLE
Facter puppet4 fix

### DIFF
--- a/lib/facter/bitbucket_facts.rb
+++ b/lib/facter/bitbucket_facts.rb
@@ -10,12 +10,14 @@ begin
   file = File.open("/etc/bitbucket_url.txt", "rb")
   bitbucket_url = file.read
 rescue
+  puts "bitbucket_version=0"
   exit 0
 end
 begin
   url = 'bitbucket_url'
   info = open(url, &:read)
 rescue
+  puts "bitbucket_version=0"
   exit 0
 end
 pinfo = JSON.load(info)

--- a/lib/facter/bitbucket_facts.rb
+++ b/lib/facter/bitbucket_facts.rb
@@ -20,17 +20,14 @@ if File.exist? '/etc/bitbucket_url.txt'
       file = File.open("/etc/bitbucket_url.txt", "rb")
       bitbucket_url = file.read
     rescue
-      puts 'cannot open file'
       file_exists = false
     end
 end
 
 if file_exists
     begin
-      puts bitbucket_url
       info = open(bitbucket_url, &:read)
     rescue
-      puts 'cannot open url'
       url_read = false
     end
 end

--- a/lib/facter/bitbucket_facts.rb
+++ b/lib/facter/bitbucket_facts.rb
@@ -1,0 +1,24 @@
+# Fact: bitbucket_builddate, bitbucket_buildnumber, bitbucket_displayname, bitbucket_version
+#
+# Purpose: Return facts for the running version of bitbucket.
+#
+require 'json'
+require 'open-uri'
+
+# get url of bitbucket
+file = File.open("/etc/bitbucket_url.txt", "rb")
+bitbucket_url = file.read
+begin
+  url = 'bitbucket_url'
+  info = open(url, &:read)
+rescue
+  exit 0
+end
+pinfo = JSON.load(info)
+pinfo.each do |key, value|
+  actual_value = value
+  if value.is_a? Array
+     actual_value = value.join(',')
+  end
+  puts "bitbucket_#{key.chomp()}=#{actual_value.chomp}"
+end

--- a/lib/facter/bitbucket_facts.rb
+++ b/lib/facter/bitbucket_facts.rb
@@ -6,9 +6,13 @@ require 'json'
 require 'open-uri'
 
 # variables
-bitbucket_version_var = '0'
-file_exists = true
-url_read = true
+file_exists  = true
+url_read     = true
+version      = '-1'
+display_name = '-1'
+build_number = '-1'
+build_date   = '-1'
+
 
 # get url of bitbucket
 if File.exist? '/etc/bitbucket_url.txt'
@@ -16,15 +20,17 @@ if File.exist? '/etc/bitbucket_url.txt'
       file = File.open("/etc/bitbucket_url.txt", "rb")
       bitbucket_url = file.read
     rescue
+      puts 'cannot open file'
       file_exists = false
     end
 end
 
 if file_exists
     begin
-      url = 'bitbucket_url'
-      info = open(url, &:read)
+      puts bitbucket_url
+      info = open(bitbucket_url, &:read)
     rescue
+      puts 'cannot open url'
       url_read = false
     end
 end
@@ -34,15 +40,37 @@ if url_read
     pinfo.each do |key, value|
       actual_value = value
       if value.is_a? Array
-	 actual_value = value.join(',')
+         actual_value = value.join(',')
       end
-      #puts "bitbucket_#{key.chomp()}=#{actual_value.chomp}"
-      bitbucket_version_var = "bitbucket_#{key.chomp()}=#{actual_value.chomp}"
+      if key.chomp() == 'version'
+          version = "bitbucket_#{key.chomp()}=#{actual_value.chomp}"
+      elsif key.chomp() == 'buildNumber'
+          build_number = "bitbucket_#{key.chomp()}=#{actual_value.chomp}"
+      elsif key.chomp() == 'displayName'
+          display_name = "bitbucket_#{key.chomp()}=#{actual_value.chomp}"
+      elsif key.chomp() == 'buildDate'
+          build_date = "bitbucket_#{key.chomp()}=#{actual_value.chomp}"
+      end
     end
 end
 
 Facter.add(:bitbucket_version) do
   setcode do
-    bitbucket_version_var
+    version
+  end
+end
+Facter.add(:bitbucket_displayName) do
+  setcode do
+    display_name
+  end
+end
+Facter.add(:bitbucket_buildNumber) do
+  setcode do
+    build_number
+  end
+end
+Facter.add(:bitbucket_buildDate) do
+  setcode do
+    build_date
   end
 end

--- a/lib/facter/bitbucket_facts.rb
+++ b/lib/facter/bitbucket_facts.rb
@@ -6,8 +6,12 @@ require 'json'
 require 'open-uri'
 
 # get url of bitbucket
-file = File.open("/etc/bitbucket_url.txt", "rb")
-bitbucket_url = file.read
+begin
+  file = File.open("/etc/bitbucket_url.txt", "rb")
+  bitbucket_url = file.read
+rescue
+  exit 0
+end
 begin
   url = 'bitbucket_url'
   info = open(url, &:read)

--- a/lib/facter/bitbucket_facts.rb
+++ b/lib/facter/bitbucket_facts.rb
@@ -5,26 +5,44 @@
 require 'json'
 require 'open-uri'
 
+# variables
+bitbucket_version_var = '0'
+file_exists = true
+url_read = true
+
 # get url of bitbucket
-begin
-  file = File.open("/etc/bitbucket_url.txt", "rb")
-  bitbucket_url = file.read
-rescue
-  puts "bitbucket_version=0"
-  exit 0
+if File.exist? '/etc/bitbucket_url.txt'
+    begin
+      file = File.open("/etc/bitbucket_url.txt", "rb")
+      bitbucket_url = file.read
+    rescue
+      file_exists = false
+    end
 end
-begin
-  url = 'bitbucket_url'
-  info = open(url, &:read)
-rescue
-  puts "bitbucket_version=0"
-  exit 0
+
+if file_exists
+    begin
+      url = 'bitbucket_url'
+      info = open(url, &:read)
+    rescue
+      url_read = false
+    end
 end
-pinfo = JSON.load(info)
-pinfo.each do |key, value|
-  actual_value = value
-  if value.is_a? Array
-     actual_value = value.join(',')
+
+if url_read
+    pinfo = JSON.load(info)
+    pinfo.each do |key, value|
+      actual_value = value
+      if value.is_a? Array
+	 actual_value = value.join(',')
+      end
+      #puts "bitbucket_#{key.chomp()}=#{actual_value.chomp}"
+      bitbucket_version_var = "bitbucket_#{key.chomp()}=#{actual_value.chomp}"
+    end
+end
+
+Facter.add(:bitbucket_version) do
+  setcode do
+    bitbucket_version_var
   end
-  puts "bitbucket_#{key.chomp()}=#{actual_value.chomp}"
 end

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -22,37 +22,15 @@ class bitbucket::facts(
   $json_packages = $bitbucket::params::json_packages,
 ) inherits bitbucket {
 
-  # Puppet Enterprise supplies its own ruby version if your using it.
-  # A modern ruby version is required to run the executable fact
-  if $::puppetversion =~ /Puppet Enterprise/ {
-    $ruby_bin = '/opt/puppet/bin/ruby'
-    $dir      = 'puppetlabs/'
-  } else {
-    $ruby_bin = '/usr/bin/env ruby'
-    $dir      = ''
-  }
-
-  if ! defined(File["/etc/${dir}facter"]) {
-    file { "/etc/${dir}facter":
-      ensure  => directory,
-    }
-  }
-  if ! defined(File["/etc/${dir}facter/facts.d"]) {
-    file { "/etc/${dir}facter/facts.d":
-      ensure  => directory,
-    }
-  }
-
   if $::osfamily == 'RedHat' and $::puppetversion !~ /Puppet Enterprise/ {
     package { $json_packages:
       ensure => present,
     }
   }
 
-  file { "/etc/${dir}facter/facts.d/bitbucket_facts.rb":
+  file{'/etc/bitbucket_url.txt':
     ensure  => $ensure,
-    content => template('bitbucket/facts.rb.erb'),
-    mode    => '0500',
+    content => "http://${uri}:${port}${context_path}/rest/api/1.0/\
+application-properties",
   }
-
 }

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -20,6 +20,7 @@ class bitbucket::facts(
   $uri           = '127.0.0.1',
   $context_path  = $bitbucket::context_path,
   $json_packages = $bitbucket::params::json_packages,
+  $is_https      = false,
 ) inherits bitbucket {
 
   if $::osfamily == 'RedHat' and $::puppetversion !~ /Puppet Enterprise/ {
@@ -28,9 +29,15 @@ class bitbucket::facts(
     }
   }
 
+  if $is_https {
+    $http = 'https://'
+  }else{
+    $http = 'http://'
+  }
+
   file{'/etc/bitbucket_url.txt':
     ensure  => $ensure,
-    content => "http://${uri}:${port}${context_path}/rest/api/1.0/\
+    content => "${http}${uri}:${port}${context_path}/rest/api/1.0/\
 application-properties",
   }
 }

--- a/manifests/gc.pp
+++ b/manifests/gc.pp
@@ -27,7 +27,7 @@ class bitbucket::gc(
 
   include ::bitbucket::params
 
-  if versioncmp($::bitbucket_version, '3.2') < 0 {
+  if $::bitbucket_version and versioncmp($::bitbucket_version, '3.2') < 0 {
     $shared = ''
   } else {
     $shared = '/shared'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -92,7 +92,8 @@ class bitbucket(
   if $::bitbucket_version {
     # If the running version of bitbucket is less than the expected version of bitbucket
     # Shut it down in preparation for upgrade.
-    if versioncmp($version, $::bitbucket_version) > 0 {
+    if $::bitbucket_version != '-1' and
+    versioncmp($version, $::bitbucket_version) > 0 {
       notify { 'Attempting to upgrade bitbucket': }
       exec { $stop_bitbucket: }
       if versioncmp($version, '3.2.0') > 0 {


### PR DESCRIPTION
I have debugged the initial issues that I had this with PR and am now resubmitting.

The bitbucket module doesn't work when using the bitbucket::gc class in a Puppet 4 environment. This is caused primarily by the the bitbucket_version variable not being set due to facter pathing. This patch does the following to fix this problem:

- Removed using the global fact directory.
- Moved facts to the module 'lib' directory.
- Added a configuration file in /etc.
- Fails gracefully if fact is unavailable.