### PR TITLE
setenv.sh is not called until after start-search.sh on systemd system

### DIFF
--- a/templates/bitbucket.service.erb
+++ b/templates/bitbucket.service.erb
@@ -5,6 +5,7 @@ After=syslog.target network.target
 [Service]
 Type=forking
 Environment="JAVA_HOME=<%= scope.lookupvar('bitbucket::javahome') %>"
+Environment="BITBUCKET_HOME=<%= scope.lookupvar('bitbucket::homedir') %>"
 PIDFile=<%= scope.lookupvar('bitbucket::webappdir') %>/work/catalina.pid
 User=<%= scope.lookupvar('bitbucket::user') %>
 ExecStart=<%= scope.lookupvar('bitbucket::webappdir') %>/bin/start-bitbucket.sh


### PR DESCRIPTION
setenv.sh is not called until after start-search.sh on systemd systems, so BITBUCKET_HOME needs to be set in the .service file otherwise Elasticsearch cannot start.