### PR TITLE
Use systemd for service management on ubuntu 16.04

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,8 +20,13 @@ class bitbucket::params {
       }
     } /Debian/: {
       $json_packages           = [ 'rubygem-json', 'ruby-json' ]
-      $service_file_location   = '/etc/init.d/bitbucket'
-      $service_file_template   = 'bitbucket/bitbucket.initscript.debian.erb'
+      if $::operatingsystemmajrelease == '16.04' {
+        $service_file_location = '/etc/systemd/system/bitbucket.service'
+        $service_file_template = 'bitbucket/bitbucket.service.erb'
+      } else {
+        $service_file_location = '/etc/init.d/bitbucket'
+        $service_file_template = 'bitbucket/bitbucket.initscript.debian.erb'
+      }
       $service_lockfile        = '/var/lock/bitbucket'
     } default: {
       fail("${::operatingsystem} ${::operatingsystemmajrelease} not supported")

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -25,7 +25,7 @@ class bitbucket::service  (
     validate_string($service_ensure)
     validate_bool($service_enable)
 
-    if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == '7' {
+    if ($::osfamily == 'RedHat' and $::operatingsystemmajrelease == '7') or ($::osfamily == 'Debian' and $::operatingsystemmajrelease == '16.04') {
       exec { 'refresh_systemd':
         command     => 'systemctl daemon-reload',
         refreshonly => true,


### PR DESCRIPTION
This just adds another check for ubuntu 16.04 to determine which variant to use.

As an alternative to this explicit check `stdlib` since version 4.10 provides a `service_provider` fact that could be used to determine whether to install sysvinit or systemd files, but that would require a raise of the `stdlib` dependency.