### PR TITLE
Fix unnecessary inclussion of archive class

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,8 +20,6 @@ class bitbucket::install(
   $webappdir,
   ) {
 
-  include '::archive'
-
   if $manage_usr_grp {
     #Manage the group in the module
     group { $group:
@@ -92,6 +90,7 @@ class bitbucket::install(
       }
     }
     'archive': {
+      include '::archive'
       $checksum_verify = $checksum ? { undef => false, default => true }
       archive { "/tmp/${file}":
         ensure          => present,


### PR DESCRIPTION
When using staging as deploy module, archive is included nevertheless, causing errors if not installed. This moves the inclussion into the case statement.