### PR TITLE
Fixed default permissions for service unit file

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -17,7 +17,7 @@ class bitbucket::service  (
 
   file { $service_file_location:
     content => template($service_file_template),
-    mode    => '0755',
+    mode    => '0644',
   }
 
   if $bitbucket::service_manage {


### PR DESCRIPTION
This avoids getting a warning in syslog:
systemd[1]: Configuration file /etc/systemd/system/bitbucket.service is marked executable. Please remove executable permission bits. Proceeding anyway.

Default permissions should be 0644 as can be seen in /lib/systemd/system