### PR TITLE
Use puppet/staging module instead of nanliu/staging

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -51,7 +51,7 @@
       "version_requirement": ">= 0.0.3"
     },
     {
-      "name": "nanliu/staging",
+      "name": "puppet/staging",
       "version_requirement": ">= 1.0.0"
     },
     {


### PR DESCRIPTION
I am getting module dependency clashes because some of my existing modules use the puppet/staging modules and in my setup two modules with identical names can't co-exist.

I believe that the nanliu/staging module has been superseded by puppet/staging, so I propose updating your module to use puppet/staging instead.