### PR TITLE
Use service_provider fact to determine init system

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,9 @@ Metrics/BlockLength:
   Enabled: false
 
 # dealbreaker:
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+Style/TrailingCommaInArrayLiteral:
   Enabled: false
 Style/TrailingCommaInArguments:
   Enabled: false

--- a/lib/facter/bitbucket_facts.rb
+++ b/lib/facter/bitbucket_facts.rb
@@ -25,7 +25,7 @@ end
 
 if file_exists
   begin
-    info = open(bitbucket_url, &:read)
+    info = OpenURI.open_uri(bitbucket_url, &:read)
   rescue
     url_read = false
   end

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,31 +5,38 @@
 class bitbucket::params {
   case $::osfamily {
     /RedHat/: {
+      $systemd_unit_dir = '/usr/lib/systemd/system'
+      $init_template    = 'bitbucket.initscript.redhat.erb'
+      $service_lockfile = '/var/lock/subsys/bitbucket'
+
       if $::operatingsystemmajrelease == '7' {
-        $json_packages           = 'rubygem-json'
-        $service_file_location   = '/usr/lib/systemd/system/bitbucket.service'
-        $service_file_template   = 'bitbucket/bitbucket.service.erb'
-        $service_lockfile        = '/var/lock/subsys/bitbucket'
+        $json_packages = 'rubygem-json'
       } elsif $::operatingsystemmajrelease == '6' {
-        $json_packages           = [ 'ruby-json', 'rubygem-json' ]
-        $service_file_location   = '/etc/init.d/bitbucket'
-        $service_file_template   = 'bitbucket/bitbucket.initscript.redhat.erb'
-        $service_lockfile        = '/var/lock/subsys/bitbucket'
+        $json_packages         = [ 'ruby-json', 'rubygem-json' ]
       } else {
         fail("${::operatingsystem} ${::operatingsystemmajrelease} not supported")
       }
     } /Debian/: {
-      $json_packages           = [ 'rubygem-json', 'ruby-json' ]
-      if $::operatingsystemmajrelease == '16.04' {
-        $service_file_location = '/etc/systemd/system/bitbucket.service'
-        $service_file_template = 'bitbucket/bitbucket.service.erb'
-      } else {
-        $service_file_location = '/etc/init.d/bitbucket'
-        $service_file_template = 'bitbucket/bitbucket.initscript.debian.erb'
-      }
-      $service_lockfile        = '/var/lock/bitbucket'
+      $systemd_unit_dir = '/etc/systemd/system'
+      $init_template    = 'bitbucket.initscript.debian.erb'
+      $service_lockfile = '/var/lock/bitbucket'
+      $json_packages    = [ 'rubygem-json', 'ruby-json' ]
     } default: {
       fail("${::operatingsystem} ${::operatingsystemmajrelease} not supported")
     }
   }
+
+  case $service_provider {
+    'systemd': {
+      $service_file_location = "${systemd_unit_dir}/bitbucket.service"
+      $service_file_template = 'bitbucket/bitbucket.service.erb'
+      $service_file_mode     = '0644'
+    }
+    default: {
+      $service_file_location = '/etc/init.d/bitbucket'
+      $service_file_template = "bitbucket/${init_template}"
+      $service_file_mode     = '0754'
+    }
+  }
+
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -8,6 +8,7 @@ class bitbucket::service  (
   $service_ensure        = $bitbucket::service_ensure,
   $service_enable        = $bitbucket::service_enable,
   $service_file_location = $bitbucket::params::service_file_location,
+  $service_file_mode     = $bitbucket::params::service_file_mode,
   $service_file_template = $bitbucket::params::service_file_template,
   $service_lockfile      = $bitbucket::params::service_lockfile,
 
@@ -17,7 +18,7 @@ class bitbucket::service  (
 
   file { $service_file_location:
     content => template($service_file_template),
-    mode    => '0644',
+    mode    => $service_file_mode,
   }
 
   if $bitbucket::service_manage {


### PR DESCRIPTION
This commit accomplishes two things:

* Better support for using systemd on Debian based systems with systemd
* Sets correct file mode for sysv style init scripts

Systems with sysv style init scripts were probably broken with commit 39297d617192e7155cb4918a3b8da1c3f6ee3ad1. Mode 644 makes sense for unit files, but sysv style init scripts needs to be executable.

I added some commits to fix CI issues as well.