### PR TITLE
Unable to add the '--no-search' flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ Should puppet manage this service? Default: true
 Manage the bitbucket service, defaults to 'running'
 ##### `$service_enable`
 Defaults to 'true'
+##### `$service_options`
+Add options to the `start-bitbucket.sh` script. Example: `--no-search`. Defaults to ''.
 ##### `$stop_bitbucket`
 If the bitbucket service is managed outside of puppet the stop_bitbucket paramater can be used to shut down bitbucket for upgrades. Defaults to 'service bitbucket stop && sleep 15'
 ##### `deploy_module`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,6 +67,7 @@ class bitbucket(
   $service_manage = true,
   $service_ensure = running,
   $service_enable = true,
+  $service_options = '',
 
   # Reverse https proxy
   $proxy = {},

--- a/templates/bitbucket.initscript.debian.erb
+++ b/templates/bitbucket.initscript.debian.erb
@@ -69,7 +69,7 @@ run_with_home() {
 #
 do_start()
 {
-    run_with_home start-bitbucket.sh
+    run_with_home start-bitbucket.sh <%= scope.lookupvar('bitbucket::service_options') %>
 }
 #
 # Function that stops the daemon/service

--- a/templates/bitbucket.initscript.redhat.erb
+++ b/templates/bitbucket.initscript.redhat.erb
@@ -62,7 +62,7 @@ function stop() {
 
 function start() {
   echo -n $"Starting $SERVICE: "
-  ${sucmd} <%= scope.lookupvar('bitbucket::webappdir') %>/bin/start-bitbucket.sh
+  ${sucmd} <%= scope.lookupvar('bitbucket::webappdir') %>/bin/start-bitbucket.sh <%= scope.lookupvar('bitbucket::service_options') %>
   RETVAL=$?
   echo
 

--- a/templates/bitbucket.service.erb
+++ b/templates/bitbucket.service.erb
@@ -12,7 +12,7 @@ PIDFile=<%= scope.lookupvar('bitbucket::homedir') %>/log/bitbucket.pid
 PIDFile=<%= scope.lookupvar('bitbucket::webappdir') %>/work/catalina.pid
 <% end -%>
 User=<%= scope.lookupvar('bitbucket::user') %>
-ExecStart=<%= scope.lookupvar('bitbucket::webappdir') %>/bin/start-bitbucket.sh
+ExecStart=<%= scope.lookupvar('bitbucket::webappdir') %>/bin/start-bitbucket.sh <%= scope.lookupvar('bitbucket::service_options') %>
 ExecStop=<%= scope.lookupvar('bitbucket::webappdir') %>/bin/stop-bitbucket.sh
 
 [Install]


### PR DESCRIPTION
Proposal to fix issue #57 
Works on my installation: the local elastic search instance is not started when bitbucket starts.
Does this PR require a new test case @danofthewired ?