### PR TITLE
switch to using ensure_packages to avoid conflicts

### DIFF
--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -24,9 +24,7 @@ class bitbucket::facts(
 ) inherits bitbucket {
 
   if $::osfamily == 'RedHat' and $::puppetversion !~ /Puppet Enterprise/ {
-    package { $json_packages:
-      ensure => present,
-    }
+    ensure_packages ($json_packages, { ensure => present })
   }
 
   if $is_https {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@ class bitbucket::params {
       $service_lockfile = '/var/lock/subsys/bitbucket'
 
       if $::operatingsystemmajrelease == '7' {
-        $json_packages = 'rubygem-json'
+        $json_packages = [ 'rubygem-json' ]
       } elsif $::operatingsystemmajrelease == '6' {
         $json_packages         = [ 'ruby-json', 'rubygem-json' ]
       } else {


### PR DESCRIPTION
If sharing the same server for several atlassian products (crowd, jira, confluence, bitbucket) there may be conflicts with packages.  This shows up with the bitbucket and jira modules both expecting one or both of `rubygem-json` and `ruby-json`.  Switching to `ensure_packages` allows both projects to declare the package requirement.

Corresponding PR in related project: https://github.com/voxpupuli/puppet-jira/pull/250