### PR TITLE
Maintain vendor intended log defaults, expose log maxhistory and maxsize, fix maillog pattern

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,14 +16,16 @@ class bitbucket(
   $additional_env = undef,
 
   # Bitbucket Settings
-  $version      = '5.10.0',
-  $product      = 'bitbucket',
-  $format       = 'tar.gz',
-  $installdir   = '/opt/bitbucket',
-  $homedir      = '/home/bitbucket',
-  $context_path = '',
-  $tomcat_port  = 7990,
-  $logdir       = "${homedir}/log",
+  $version        = '5.10.0',
+  $product        = 'bitbucket',
+  $format         = 'tar.gz',
+  $installdir     = '/opt/bitbucket',
+  $homedir        = '/home/bitbucket',
+  $context_path   = '',
+  $tomcat_port    = 7990,
+  $logdir         = "${homedir}/log",
+  $log_maxhistory = '31', # days
+  $log_maxsize    = '25MB',
 
   # User and Group Management Settings
   $manage_usr_grp = true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,7 +23,7 @@ class bitbucket(
   $homedir      = '/home/bitbucket',
   $context_path = '',
   $tomcat_port  = 7990,
-  $logdir       = '/var/log/bitbucket',
+  $logdir       = "${homedir}/log",
 
   # User and Group Management Settings
   $manage_usr_grp = true,

--- a/templates/elasticsearch.yml.erb
+++ b/templates/elasticsearch.yml.erb
@@ -5,7 +5,7 @@ node:
 network.host: _local_
 
 path:
-  logs: <%= scope.lookupvar('bitbucket::logdir') %>
+  logs: <%= scope.lookupvar('bitbucket::logdir') %>/search
   data: ${BITBUCKET_HOME}/shared/search/data
 
 action.auto_create_index: false

--- a/templates/logback.xml.erb
+++ b/templates/logback.xml.erb
@@ -29,7 +29,7 @@
                 <file><%= scope.lookupvar('bitbucket::logdir') %>/atlassian-bitbucket.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
                     <fileNamePattern><%= scope.lookupvar('bitbucket::logdir') %>/atlassian-bitbucket-%d.log</fileNamePattern>
-                    <maxHistory>31</maxHistory>
+		    <maxHistory><%= scope.lookupvar('bitbucket::log_maxhistory') %></maxHistory>
                 </rollingPolicy>
             </appender>
 
@@ -41,7 +41,7 @@
                 <file><%= scope.lookupvar('bitbucket::logdir') %>/atlassian-bitbucket-profiler.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
                     <fileNamePattern><%= scope.lookupvar('bitbucket::logdir') %>/atlassian-bitbucket-profiler-%d.%i.log</fileNamePattern>
-                    <maxFileSize>25MB</maxFileSize>
+		    <maxFileSize><%= scope.lookupvar('bitbucket::log_maxsize') %></maxFileSize>
                     <maxHistory>3</maxHistory>
                 </rollingPolicy>
             </appender>
@@ -54,7 +54,7 @@
                 <file><%= scope.lookupvar('bitbucket::logdir') %>/atlassian-bitbucket-access.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
                     <fileNamePattern><%= scope.lookupvar('bitbucket::logdir') %>/atlassian-bitbucket-access-%d.%i.log</fileNamePattern>
-                    <maxFileSize>25MB</maxFileSize>
+		    <maxFileSize><%= scope.lookupvar('bitbucket::log_maxsize') %></maxFileSize>
                     <maxHistory>10</maxHistory>
                 </rollingPolicy>
             </appender>
@@ -67,7 +67,7 @@
                 <file><%= scope.lookupvar('bitbucket::logdir') %>/audit/atlassian-bitbucket-audit.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
                     <fileNamePattern><%= scope.lookupvar('bitbucket::logdir') %>/audit/atlassian-bitbucket-audit-%d.%i.log.gz</fileNamePattern>
-                    <maxFileSize>25MB</maxFileSize>
+		    <maxFileSize><%= scope.lookupvar('bitbucket::log_maxsize') %></maxFileSize>
                     <maxHistory>100</maxHistory>
                 </rollingPolicy>
             </appender>
@@ -80,7 +80,7 @@
                 <file><%= scope.lookupvar('bitbucket::logdir') %>/atlassian-bitbucket-alerts.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
                     <fileNamePattern><%= scope.lookupvar('bitbucket::logdir') %>/atlassian-bitbucket-alerts-%d.log</fileNamePattern>
-                    <maxHistory>31</maxHistory>
+		    <maxHistory><%= scope.lookupvar('bitbucket::log_maxhistory') %></maxHistory>
                 </rollingPolicy>
             </appender>
 
@@ -92,7 +92,7 @@
                 <file><%= scope.lookupvar('bitbucket::logdir') %>/atlassian-bitbucket-mail.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
                     <fileNamePattern><%= scope.lookupvar('bitbucket::logdir') %>/atlassian-bitbucket-mail-%d.%i.log</fileNamePattern>
-                    <maxFileSize>25MB</maxFileSize>
+		    <maxFileSize><%= scope.lookupvar('bitbucket::log_maxsize') %></maxFileSize>
                     <maxHistory>10</maxHistory>
                 </rollingPolicy>
             </appender>

--- a/templates/logback.xml.erb
+++ b/templates/logback.xml.erb
@@ -87,7 +87,7 @@
             <appender name="bitbucket.maillog" class="ch.qos.logback.core.rolling.RollingFileAppender">
                 <encoder>
                     <charset>UTF-8</charset>
-                    <pattern>${xpass.log.format}</pattern>
+                    <pattern>${log.format}</pattern>
                 </encoder>
                 <file><%= scope.lookupvar('bitbucket::logdir') %>/atlassian-bitbucket-mail.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">


### PR DESCRIPTION
2c5355a9f6bb2fa877ec3b6f1969ecb7f496f24a attempts to maintain the vendor desired log location, while adding optional log_dir configuration provided by e3afce891dc4e36dab19acf17ea06bed9e6b8926 

Default log maxhistory for some logs is 31 days, and maxsize 25MB. Expose those values for logs which have a default of 31 days and likely to get get very large and cause space issues. 

maillog pattern was changed when logback.xml was added for some reason breaking the maillog.