### PR TITLE
#80 - Bitbucket-7.21 does not provide elasticsearch config template

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -98,15 +98,20 @@ class bitbucket::config(
     ],
   }
 
-  if versioncmp($version, '7.21.0') < 0 {
-    file { "${bitbucket::webappdir}/elasticsearch/config-template/elasticsearch.yml":
-      content => template('bitbucket/elasticsearch.yml.erb'),
-      mode    => '0640',
-      require => [
-        Class['bitbucket::install'],
-        File[$bitbucket::webappdir],
-      ],
-    }
+  if versioncmp($version, '7.21') >= 0 {
+    $search_config = "${bitbucket::webappdir}/opensearch/config/opensearch.yml"
+    $search_config_template = 'bitbucket/opensearch.yml.erb'
+  } else {
+    $search_config = "${bitbucket::webappdir}/elasticsearch/config-template/elasticsearch.yml"
+    $search_config_template = 'bitbucket/elasticsearch.yml.erb'
+  }
+  file { $search_config:
+    content => template($search_config_template),
+    mode    => '0640',
+    require => [
+      Class['bitbucket::install'],
+      File[$bitbucket::webappdir],
+    ],
   }
 
   file { "${bitbucket::webappdir}/app/WEB-INF/classes/logback.xml":

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -98,13 +98,15 @@ class bitbucket::config(
     ],
   }
 
-  file { "${bitbucket::webappdir}/elasticsearch/config-template/elasticsearch.yml":
-    content => template('bitbucket/elasticsearch.yml.erb'),
-    mode    => '0640',
-    require => [
-      Class['bitbucket::install'],
-      File[$bitbucket::webappdir],
-    ],
+  if versioncmp($version, '7.21.0') < 0 {
+    file { "${bitbucket::webappdir}/elasticsearch/config-template/elasticsearch.yml":
+      content => template('bitbucket/elasticsearch.yml.erb'),
+      mode    => '0640',
+      require => [
+        Class['bitbucket::install'],
+        File[$bitbucket::webappdir],
+      ],
+    }
   }
 
   file { "${bitbucket::webappdir}/app/WEB-INF/classes/logback.xml":

--- a/manifests/facts.pp
+++ b/manifests/facts.pp
@@ -23,7 +23,7 @@ class bitbucket::facts(
   $is_https      = false,
 ) inherits bitbucket {
 
-  if $::osfamily == 'RedHat' and $::puppetversion !~ /Puppet Enterprise/ {
+  if $facts['os']['family'] == 'RedHat' and $::puppetversion !~ /Puppet Enterprise/ {
     ensure_packages ($json_packages, { ensure => present })
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,7 +98,7 @@ class bitbucket(
 
 ) {
 
-  validate_hash($config_properties)
+  assert_type(Hash, $config_properties)
 
   include ::bitbucket::params
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,7 @@
 # Defines default values for bitbucket module
 #
 class bitbucket::params {
-  case $::osfamily {
+  case $facts['os']['family'] {
     /RedHat/: {
       $systemd_unit_dir = '/usr/lib/systemd/system'
       $init_template    = 'bitbucket.initscript.redhat.erb'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -26,7 +26,7 @@ class bitbucket::service  (
     assert_type(String, $service_ensure)
     assert_type(Boolean, $service_enable)
 
-    if ($facts['os']['family'] == 'RedHat' and $facts['os']['release']['full'] == '7') or ($::osfamily == 'Debian' and $facts['os']['release']['full'] == '16.04') {
+    if ($facts['os']['family'] == 'RedHat' and $facts['os']['release']['full'] == '7') or ($facts['os']['family'] == 'Debian' and $facts['os']['release']['full'] == '16.04') {
       exec { 'bitbucket_refresh_systemd':
         command     => 'systemctl daemon-reload',
         refreshonly => true,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -26,7 +26,7 @@ class bitbucket::service  (
     assert_type(String, $service_ensure)
     assert_type(Boolean, $service_enable)
 
-    if ($::osfamily == 'RedHat' and $::operatingsystemmajrelease == '7') or ($::osfamily == 'Debian' and $::operatingsystemmajrelease == '16.04') {
+    if ($facts['os']['family'] == 'RedHat' and $facts['os']['release']['full'] == '7') or ($::osfamily == 'Debian' and $facts['os']['release']['full'] == '16.04') {
       exec { 'bitbucket_refresh_systemd':
         command     => 'systemctl daemon-reload',
         refreshonly => true,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -14,7 +14,7 @@ class bitbucket::service  (
 
 ) {
 
-  validate_bool($service_manage)
+  assert_type(Boolean, $service_manage)
 
   if $bitbucket::service_manage {
 
@@ -23,8 +23,8 @@ class bitbucket::service  (
       mode    => $service_file_mode,
     }
 
-    validate_string($service_ensure)
-    validate_bool($service_enable)
+    assert_type(String, $service_ensure)
+    assert_type(Boolean, $service_enable)
 
     if ($::osfamily == 'RedHat' and $::operatingsystemmajrelease == '7') or ($::osfamily == 'Debian' and $::operatingsystemmajrelease == '16.04') {
       exec { 'bitbucket_refresh_systemd':

--- a/templates/opensearch.yml.erb
+++ b/templates/opensearch.yml.erb
@@ -1,0 +1,38 @@
+cluster.name: bitbucket_search
+node:
+  name: bitbucket_bundled
+
+network.host: _local_
+discovery.type: single-node
+
+path:
+  logs: <%= scope.lookupvar('bitbucket::logdir') %>/search
+  data: ${BITBUCKET_HOME}/shared/search/data
+
+action.auto_create_index: false
+
+http.port: 7992
+transport.tcp.port: 7993
+
+# The OpenSearch security plugin stores its configuration in an index in the cluster itself. On startup if the
+# security index doesn't exist yet, sitting this to true will cause the security plugin to read the yml files and
+# configure the index using the contents of the files.
+plugins.security.allow_default_init_securityindex: true
+
+# Using the yml files with default initialisation, we create a bitbucket user and give it the all_access in-built role.
+# However, access to the REST API is disabled by default even for the all_access role so we need to explicitly give
+# it permission here so that the bitbucket user can access the OpenSearch REST API.
+plugins.security.restapi.roles_enabled: ["all_access"]
+
+# Mandatory TLS setup for transport layer
+plugins.security.authcz.admin_dn:
+  - CN=BITBUCKET
+plugins.security.ssl.transport.enforce_hostname_verification: false
+plugins.security.ssl.transport.pemcert_filepath: bitbucket.pem
+plugins.security.ssl.transport.pemkey_filepath: bitbucket-key.pem
+plugins.security.ssl.transport.pemtrustedcas_filepath: root-ca.pem
+
+# Logs audit events to bitbucket_search_server.json
+plugins.security.audit.type: log4j
+plugins.security.audit.config.log4j.logger_name: audit
+plugins.security.audit.config.log4j.level: INFO


### PR DESCRIPTION
Bitbucket has disabled elastsearch from version 7.21 ( https://confluence.atlassian.com/bitbucketserver/bitbucket-data-center-and-server-7-21-release-notes-1115129015.html )